### PR TITLE
Feature/empty response management

### DIFF
--- a/DockerSwift.podspec
+++ b/DockerSwift.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name                    = 'DockerSwift'
-  s.version                 = '1.0.0'
+  s.version                 = '1.0.1'
   s.platform                = :ios
   s.ios.deployment_target   = '9.0'
   s.swift_version           = '4.2'

--- a/DockerSwift/Classes/Service/ServiceManager.swift
+++ b/DockerSwift/Classes/Service/ServiceManager.swift
@@ -155,14 +155,12 @@ open class ServiceManager { // : Singleton, Initializable
             let retrievedData = !(data?.isEmpty ?? true) ? data : nil
             let responseClass = Resp.self
             var responseError: DockerError?
-            switch (urlResponse, retrievedData, error) {
-            case let (.some(urlResponse), .some(retrievedData), .none):
-                response = responseClass.init(statusCode: urlResponse.statusCode, data: retrievedData, request: serviceCall.request, response: urlResponse)
-                break
-            case let (.some(urlResponse), .some(retrievedData), .some(error)):
-                response = responseClass.init(statusCode: urlResponse.statusCode, data: retrievedData, request: serviceCall.request, response: urlResponse)
+            switch (urlResponse, error) {
+            case let (.some(urlResponse), .none):
+                response = responseClass.init(statusCode: urlResponse.statusCode, data: retrievedData ?? Data(), request: serviceCall.request, response: urlResponse)
+            case let (.some(urlResponse), .some(error)):
+                response = responseClass.init(statusCode: urlResponse.statusCode, data: retrievedData ?? Data(), request: serviceCall.request, response: urlResponse)
                 responseError = DockerError.underlying(error, urlResponse, response.httpStatusCode)
-                break
             default:
                 response = responseClass.init(statusCode: 0, data: data ?? Data(), request: serviceCall.request, response: urlResponse)
                 var httpErrorCode = NSURLErrorUnknown


### PR DESCRIPTION
Considers missing response errors only in case there isn't any response. In case of success responses with empty data (empty body, ex. 204 status code), it won't be considered an error.